### PR TITLE
Enable Link-Time Optimization (LTO)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ categories = ["command-line-utilities"]
 regex = "1.0"
 structopt = "0.2"
 dirs = "1.0"
+
+[profile.release]
+lto = true


### PR DESCRIPTION
Hi!

One more LTO-related PR

I have made quick tests (Fedora 41, Rustc 1.83) by adding `lto = true` to the Release profile. The binary size reduction is from 2.5 Mib to 1.9 Mib.

Thank you.